### PR TITLE
work on Scala 2.11 nightly builds

### DIFF
--- a/mc/src/main/scala/org/typelevel/claimant/mc/Macros.scala
+++ b/mc/src/main/scala/org/typelevel/claimant/mc/Macros.scala
@@ -6,13 +6,13 @@ import scala.util.Properties
 
 object Macros {
 
-  private val Scala211 = """^version 2\.11\.[0-9]+$""".r
+  private val Scala211 = """2\.11\..*""".r
 
   def forVersion[A](curr: A)(for211: A): A =
     macro forVersionMacro[A]
 
   def forVersionMacro[A](c: Context)(curr: c.Expr[A])(for211: c.Expr[A]): c.Expr[A] =
-    Properties.versionString match {
+    Properties.versionNumberString match {
       case Scala211() => for211
       case _ => curr
     }


### PR DESCRIPTION
the old regex didn't recognize a Scala version number such as
2.11.12-bin-efd31ff to be a valid 2.11.x version.  this came
up in the Scala 2.11 community build

minor code improvement: the ^ anchor was redundant and was
dropped.  Scala regexes are anchored by default