### PR TITLE
bump Scala versions

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        scala: [2.11.12, 2.12.10, 2.13.1]
+        scala: [2.11.12, 2.12.11, 2.13.3]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        scala: [2.11.12, 2.12.11, 2.13.3]
+        scala: [2.11.12, 2.12.12, 2.13.3]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ property fails, ScalaCheck will show you this label.
 
 ### Quick Start
 
-Claimant supports Scala 2.11, 2.12, and 2.13.0-RC1 -- it is available
+Claimant supports Scala 2.11, 2.12, and 2.13. It is available
 from Sonatype.
 
 To include Claimant in your projects, you can use the following
@@ -289,7 +289,7 @@ obscure the underlying values.
 To measure code coverage for 2.12, do the following:
 
 ```
-$ sbt '++ 2.12.6' coreJVM/clean coverage coreJVM/test coverageReport
+$ sbt '++ 2.12.11' coreJVM/clean coverage coreJVM/test coverageReport
 ```
 
 Assuming everything works, the result should end up someplace like:

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ obscure the underlying values.
 To measure code coverage for 2.12, do the following:
 
 ```
-$ sbt '++ 2.12.11' coreJVM/clean coverage coreJVM/test coverageReport
+$ sbt '++ 2.12.12' coreJVM/clean coverage coreJVM/test coverageReport
 ```
 
 Assuming everything works, the result should end up someplace like:

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
 lazy val claimantSettings = Seq(
   organization := "org.typelevel",
-  scalaVersion := "2.12.11",
-  crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.3"),
+  scalaVersion := "2.12.12",
+  crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.3"),
   libraryDependencies ++=
     "org.scala-lang" % "scala-reflect" % scalaVersion.value ::
       "org.scalacheck" %%% "scalacheck" % "1.14.3" ::

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
 lazy val claimantSettings = Seq(
   organization := "org.typelevel",
-  scalaVersion := "2.12.8",
-  crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
+  scalaVersion := "2.12.11",
+  crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.3"),
   libraryDependencies ++=
     "org.scala-lang" % "scala-reflect" % scalaVersion.value ::
       "org.scalacheck" %%% "scalacheck" % "1.14.3" ::

--- a/core/src/test/scala/org/typelevel/claimant/RenderTest.scala
+++ b/core/src/test/scala/org/typelevel/claimant/RenderTest.scala
@@ -21,7 +21,7 @@ object RenderTest extends Properties("RenderTest") {
   test(Array(Array(3, 4), Array(5, 6)), "Array(Array(3, 4), Array(5, 6))")
   test(false, "false")
   test((), "()")
-  test('bravo, "'bravo")
+  test(Symbol("bravo"), Symbol("bravo").toString) // Symbol#toString changed in Scala 2.13.3
   test(Iterable(true, false), "Iterable(true, false)")
   test(Seq(1, 2), "Seq(1, 2)")
   test(IndexedSeq(1, 2, 3), "IndexedSeq(1, 2, 3)")


### PR DESCRIPTION
one small adjustment to test sources was needed, because `Symbol#toString` changed in Scala 2.13.3